### PR TITLE
upgrade to main lodash package to fix vulnerability CVE-2018-16487

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "release-it": "^2.3.1"
   },
   "dependencies": {
-    "lodash.isobject": "^3.0.2",
-    "lodash.merge": "^4.3.1"
+    "lodash": "^4.17.11"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-import isObject from 'lodash.isobject';
-import merge from 'lodash.merge';
+import isObject from 'lodash/isObject';
+import merge from 'lodash/merge';
 
 export default (oldState, newState) => {
     const result = { ...oldState };


### PR DESCRIPTION
Fixes #1

`npm test` passes.

Please also update https://github.com/react-stack/redux-storage to reference the fixed version once this is merged, and publish both to NPM.